### PR TITLE
Fix: Price update when value returns to 0

### DIFF
--- a/off-topic/combien2crous/index.html
+++ b/off-topic/combien2crous/index.html
@@ -207,6 +207,16 @@ document.addEventListener("DOMContentLoaded", function() {
     const value = parseFloat(this.value);
 
     if (!value || value <= 0) {
+      crousText.textContent = "0";
+      crousBourse.textContent = "0";
+      pizzaText.textContent = "0";
+      bolo.textContent = "0";
+      robux.textContent = "0";
+      gems.textContent = "0";
+      tastycrousty.textContent = "0";
+      jnr28k.textContent = "0";
+      hexacon.textContent = "0";
+      results.classList.add("hidden");
       return;
     }
 


### PR DESCRIPTION
**Issue**
When entering an amount (e.g., 10) and then changing it to 0 or clearing the field, displayed prices (CROUS meals, pizzas, etc.) were not updating and kept the previous values.

**Cause**
An early return in the input listener for empty or ≤ 0 values prevented the DOM from updating.

**Solution**
When the value is invalid or ≤ 0, all amounts are reset to “0” and the results section gets the hidden class, ensuring consistent display and hiding the section when no valid amount is provided.