### PR TITLE
Retraites (France 2024) funding-time equivalence

### DIFF
--- a/off-topic/combien2crous/index.html
+++ b/off-topic/combien2crous/index.html
@@ -107,6 +107,7 @@
     <p id="tastycrousty"><strong>0</strong> Tasty Crousty sans boisson</p>
     <p id="jnr28k"><strong>0</strong> puffs JNR 28 K</p>
     <p id="hexacon"><strong>0</strong>% d'un billet à prix réduit pour l'<a href="https://hexacon.fr/">Hexacon</a></p>
+	<p id="retraite"><strong>0 ms</strong> de financement des retraites (France, 2025)</p>
   </div>
 </div>
 <style>
@@ -191,6 +192,7 @@ document.addEventListener("DOMContentLoaded", function() {
   const tastycrousty = document.getElementById("tastycrousty").querySelector("strong");
   const jnr28k = document.getElementById("jnr28k").querySelector("strong");
   const hexacon = document.getElementById("hexacon").querySelector("strong");
+  const retraite = document.getElementById("retraite").querySelector("strong");
 
   const CROUS_PRICE = 3.3;
   const PIZZA_PRICE = 4.79;
@@ -202,7 +204,38 @@ document.addEventListener("DOMContentLoaded", function() {
   const JNR_28_K = 14;
   const HEXACON = 660;
 
+  const RETRAITE_ANNUAL_COST_EUR = 407e9; // Retraites (France, 2025) arrondi  
+  const SECONDS_PER_YEAR = 365 * 24 * 60 * 60; 
+  const RETRAITE_EUR_PER_SECOND = RETRAITE_ANNUAL_COST_EUR / SECONDS_PER_YEAR;
 
+  function formatDuration(seconds) {
+    if (!isFinite(seconds) || seconds <= 0) return "0 ms";
+
+    if (seconds < 0.001) return `${(seconds * 1e6).toFixed(2)} µs`;
+    if (seconds < 1) return `${(seconds * 1000).toFixed(2)} ms`;
+
+    let s = Math.floor(seconds);
+
+    const yearSec = SECONDS_PER_YEAR;
+    const daySec = 24 * 60 * 60;
+    const hourSec = 60 * 60;
+    const minSec = 60;
+
+    const years = Math.floor(s / yearSec); s -= years * yearSec;
+    const days = Math.floor(s / daySec); s -= days * daySec;
+    const hours = Math.floor(s / hourSec); s -= hours * hourSec;
+    const mins = Math.floor(s / minSec); s -= mins * minSec;
+
+    const parts = [];
+    if (years) parts.push(`${years} an${years > 1 ? "s" : ""}`);
+    if (days || years) parts.push(`${days} j`);
+    if (hours || days || years) parts.push(`${hours} h`);
+    parts.push(`${mins} min`);
+    parts.push(`${s} s`);
+
+    return parts.join(" ");
+  }
+	
   input.addEventListener("input", function() {
     const value = parseFloat(this.value);
 
@@ -216,6 +249,7 @@ document.addEventListener("DOMContentLoaded", function() {
       tastycrousty.textContent = "0";
       jnr28k.textContent = "0";
       hexacon.textContent = "0";
+	  retraite.textContent = "0 ms";
       results.classList.add("hidden");
       return;
     }
@@ -229,7 +263,10 @@ document.addEventListener("DOMContentLoaded", function() {
     tastycrousty.textContent = Math.round((value / CROUSTY)* 100) /100;
     jnr28k.textContent = Math.round((value / JNR_28_K)* 100) /100;
     hexacon.textContent = Math.round((value / HEXACON)* 100);
-
+	
+	const fundedSeconds = value / RETRAITE_EUR_PER_SECOND;
+	retraite.textContent = formatDuration(fundedSeconds);
+	  
     results.classList.remove("hidden");
   });
 });

--- a/off-topic/combien2crous/index.html
+++ b/off-topic/combien2crous/index.html
@@ -107,7 +107,7 @@
     <p id="tastycrousty"><strong>0</strong> Tasty Crousty sans boisson</p>
     <p id="jnr28k"><strong>0</strong> puffs JNR 28 K</p>
     <p id="hexacon"><strong>0</strong>% d'un billet à prix réduit pour l'<a href="https://hexacon.fr/">Hexacon</a></p>
-	<p id="retraite"><strong>0 ms</strong> de financement des retraites (France, 2025)</p>
+	<p id="retraite"><strong>0 ms</strong> de financement des retraites (France, 2024)</p>
   </div>
 </div>
 <style>

--- a/off-topic/combien2crous/index.html
+++ b/off-topic/combien2crous/index.html
@@ -204,7 +204,7 @@ document.addEventListener("DOMContentLoaded", function() {
   const JNR_28_K = 14;
   const HEXACON = 660;
 
-  const RETRAITE_ANNUAL_COST_EUR = 407e9; // Retraites (France, 2025) arrondi  
+  const RETRAITE_ANNUAL_COST_EUR = 407e9; // Retraites (France, 2024) arrondi cf. https://www.vie-publique[.]fr/lettre_essentiel/21 & retraites[.]fr/sites/default/files/2025-06/RA_2025_def_publi.pdf
   const SECONDS_PER_YEAR = 365 * 24 * 60 * 60; 
   const RETRAITE_EUR_PER_SECOND = RETRAITE_ANNUAL_COST_EUR / SECONDS_PER_YEAR;
 


### PR DESCRIPTION
Ajoute une nouvelle équivalence qui convertit le montant saisi en "temps de financement des retraites" basé sur le coût de la retraite en 2024 d'environ 407 Md€/an (arrondi) cf. https://www.vie-publique.fr/lettre_essentiel/21 & https://www.cor-retraites.fr/sites/default/files/2025-06/RA_2025_def_publi.pdf.

Test :
- Ouvrir la page “Combien ça coûte en CROUS ?”
- Entrer 5€, 50€, 500€ etc.
- Vérifier qu’une nouvelle ligne “retraites” apparaît et varie (µs / ms / etc.)
